### PR TITLE
make sure the editor does not re-render when text changes

### DIFF
--- a/src/AccordionWidget.js
+++ b/src/AccordionWidget.js
@@ -140,7 +140,9 @@ const AccordionWidget = ({ id, editMode }) => {
   }, []);
 
   const removeRow = useCallback((rowId) => {
-    setItems((oldItems) => oldItems.filter((oldItem) => oldItem[2] !== rowId));
+    setItems((oldItems) =>
+      oldItems.filter(([title, content, id]) => id !== rowId)
+    );
   }, []);
 
   const addRow = useCallback(() => {
@@ -175,7 +177,7 @@ const AccordionWidget = ({ id, editMode }) => {
               <div ref={editRef}>
                 {items.map((item, index) => (
                   <EditRow
-                    key={item[2]}
+                    key={item[2]} // unique key associated to each item
                     item={item}
                     index={index}
                     onItemUpdated={onItemUpdated}

--- a/src/AccordionWidget.js
+++ b/src/AccordionWidget.js
@@ -30,54 +30,57 @@ const EditRow = ({
   onItemUpdated,
   removeRow,
   pageId,
-}) => (
-  <>
-    <EditableAccordionTitle
-      style={{ backgroundColor: settings?.headerBackgroundColor }}
-    >
-      <IconChevronRight
-        className="accordion__icon--expand"
-        width={24}
-        height={24}
-        style={{ marginRight: margin300, flexShrink: 0 }}
-      />
-      <widgetSDK.uikit.RichTextEditor
-        type="full"
-        placeholder="Add title"
-        content={item[0]}
-        onContentChanged={() => onItemUpdated(index, 0)}
-        imageUploadLocation={{
-          name: "page",
-          id: pageId,
-        }}
-      />
-      <IconButton
-        icon={IconDelete}
-        onMouseDown={() => removeRow(index)}
-        type="alert"
-        isActionIcon
-        aria-label="Remove row"
-        data-tip={"Remove row"}
-        data-for={`${index}-tooltip`}
-      />
-      <Tooltip id={`${index}-tooltip`} />
-    </EditableAccordionTitle>
-    <EditableAccordionContent
-      style={{ backgroundColor: settings?.contentBackgroundColor }}
-    >
-      <widgetSDK.uikit.RichTextEditor
-        type="full"
-        placeholder="Add content"
-        content={item[1]}
-        onContentChanged={() => onItemUpdated(index, 1)}
-        imageUploadLocation={{
-          name: "page",
-          id: pageId,
-        }}
-      />
-    </EditableAccordionContent>
-  </>
-);
+}) => {
+  const [initialContent] = useState(item[1]);
+  return (
+    <>
+      <EditableAccordionTitle
+        style={{ backgroundColor: settings?.headerBackgroundColor }}
+      >
+        <IconChevronRight
+          className="accordion__icon--expand"
+          width={24}
+          height={24}
+          style={{ marginRight: margin300, flexShrink: 0 }}
+        />
+        <widgetSDK.uikit.RichTextEditor
+          type="full"
+          placeholder="Add title"
+          content={item[0]}
+          onContentChanged={() => onItemUpdated(index, 0)}
+          imageUploadLocation={{
+            name: "page",
+            id: pageId,
+          }}
+        />
+        <IconButton
+          icon={IconDelete}
+          onMouseDown={() => removeRow(index)}
+          type="alert"
+          isActionIcon
+          aria-label="Remove row"
+          data-tip={"Remove row"}
+          data-for={`${index}-tooltip`}
+        />
+        <Tooltip id={`${index}-tooltip`} />
+      </EditableAccordionTitle>
+      <EditableAccordionContent
+        style={{ backgroundColor: settings?.contentBackgroundColor }}
+      >
+        <widgetSDK.uikit.RichTextEditor
+          type="full"
+          placeholder="Add content"
+          content={initialContent}
+          onContentChanged={() => onItemUpdated(index, 1)}
+          imageUploadLocation={{
+            name: "page",
+            id: pageId,
+          }}
+        />
+      </EditableAccordionContent>
+    </>
+  );
+};
 
 const AccordionWidget = ({ id, editMode }) => {
   const editRef = useRef();

--- a/src/AccordionWidget.js
+++ b/src/AccordionWidget.js
@@ -31,6 +31,7 @@ const EditRow = ({
   removeRow,
   pageId,
 }) => {
+  const [initialTitle] = useState(item[0]);
   const [initialContent] = useState(item[1]);
   return (
     <>
@@ -46,7 +47,7 @@ const EditRow = ({
         <widgetSDK.uikit.RichTextEditor
           type="full"
           placeholder="Add title"
-          content={item[0]}
+          content={initialTitle}
           onContentChanged={() => onItemUpdated(index, 0)}
           imageUploadLocation={{
             name: "page",
@@ -55,7 +56,7 @@ const EditRow = ({
         />
         <IconButton
           icon={IconDelete}
-          onMouseDown={() => removeRow(index)}
+          onMouseDown={() => removeRow(item[2])}
           type="alert"
           isActionIcon
           aria-label="Remove row"
@@ -138,12 +139,17 @@ const AccordionWidget = ({ id, editMode }) => {
     );
   }, []);
 
-  const removeRow = useCallback((rowIndex) => {
-    setItems((oldItems) => oldItems.filter((_, i) => i !== rowIndex));
+  const removeRow = useCallback((rowId) => {
+    setItems((oldItems) => oldItems.filter((oldItem) => oldItem[2] !== rowId));
   }, []);
 
   const addRow = useCallback(() => {
-    setItems((prevItems) => [...prevItems, ["", ""]]);
+    setItems((prevItems) => [
+      ...prevItems,
+      // we cannot rely on list element indexes when removing elements from a list
+      // so we need to add a unique key for each item
+      ["", "", (Math.random() + 1).toString(36).substring(7)],
+    ]);
   }, []);
 
   useEffect(() => {
@@ -169,7 +175,7 @@ const AccordionWidget = ({ id, editMode }) => {
               <div ref={editRef}>
                 {items.map((item, index) => (
                   <EditRow
-                    key={index}
+                    key={item[2]}
                     item={item}
                     index={index}
                     onItemUpdated={onItemUpdated}

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,17 +10,19 @@ export const parseStringJSON = (string = "", defaultVal) => {
 };
 
 export const divideDataIntoRows = (data = []) =>
-  data.reduce((resultArray, item, index) => {
-    const chunkIndex = Math.floor(index / 2);
+  data
+    .reduce((resultArray, item, index) => {
+      const chunkIndex = Math.floor(index / 2);
 
-    if (!resultArray[chunkIndex]) {
-      resultArray[chunkIndex] = [];
-    }
+      if (!resultArray[chunkIndex]) {
+        resultArray[chunkIndex] = [];
+      }
 
-    resultArray[chunkIndex].push(item);
+      resultArray[chunkIndex].push(item);
 
-    return resultArray;
-  }, []);
+      return resultArray;
+    }, [])
+    .map((array) => [...array, (Math.random() + 1).toString(36).substring(7)]);
 
 export const getContentFromFroala = (element) => {
   const data = [];


### PR DESCRIPTION
Issue 1: when the content changes, the model from RichTextEditor changes, forcing the focus at the end of the text.
Issue 2: never rely on list element indexes when removing an element from that list

Steps to reproduce for Issue 1:

1. In the accordion widget, in the body add a couple of sentences separated by new lines.
2. Try to add more text in the first sentence/line

Expected: text should be added in the first sentence.
Before: text was added at the end of the whole text.

Steps to reproduce for Issue 2:
Add multiple rows/items in the widget
Remove some of them.

Expected: we are deleting the correct item